### PR TITLE
Update RobotsTxtValidator.php

### DIFF
--- a/RobotsTxtValidator.php
+++ b/RobotsTxtValidator.php
@@ -38,6 +38,8 @@ class RobotsTxtValidator
 		$relativeUrl = $this->getRelativeUrl($url);
 
 		$orderedDirectives = $this->getOrderedDirectivesByUserAgent($userAgent);
+		// if find no directive for particular User Agent then find for all '*' 
+		if (count($orderedDirectives) == 0 && $userAgent != '*') { $orderedDirectives = $this->getOrderedDirectivesByUserAgent('*'); }
 
 		// if has not allow rules we can determine when url disallowed even on one coincidence - just to do it faster.
 		$hasAllowDirectives = true;


### PR DESCRIPTION
If specify User Agent when call `isUrlAllow()` and the User Agent is not find in the content of the robots.txt file, `isUrlAllow()` not handled correctly if there is `User-agent: *` in content of robots.txt.